### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/source/shared_cudpp/doc/bib/cudpp.bib
+++ b/source/shared_cudpp/doc/bib/cudpp.bib
@@ -391,7 +391,7 @@
   number =       8,
   publisher =    {Blackwell Publishing Ltd},
   issn =         {1467-8659},
-  url =          {http://dx.doi.org/10.1111/j.1467-8659.2009.01542.x},
+  url =          {https://doi.org/10.1111/j.1467-8659.2009.01542.x},
   doi =          {10.1111/j.1467-8659.2009.01542.x},
   pages =        {2368--2378},
   keywords =     {HPC, GPGPU, GPU sorting, collision detection,
@@ -411,7 +411,7 @@
   pages =        "77--88",
   isbn =         "978-0-12-385963-1",
   doi =
-                  "http://dx.doi.org/10.1016/B978-0-12-385963-1.00007-1",
+                  "https://doi.org/10.1016/B978-0-12-385963-1.00007-1",
   author =       "Pawan Harish and P. J. Narayanan and Vibhav Vineet
                   and Suryakant Patidar"
 }

--- a/source/shared_cudpp/doc/bib/cudpp_refs.html
+++ b/source/shared_cudpp/doc/bib/cudpp_refs.html
@@ -15,7 +15,7 @@ Daniele D'Agostino and Frank&nbsp;J Seinstra.
  <em>Journal of Computational and Applied Mathematics</em>, 273:383&ndash;393,
   January 2015.
 [&nbsp;<a href="cudpp_refs_bib.html#DAgostino:2014:API">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1016/j.cam.2014.05.019">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1016/j.cam.2014.05.019">DOI</a>&nbsp;]
 
 </p>
 
@@ -37,7 +37,7 @@ Apostolos Glenis and Sergios Petridis.
  In <em>International Conference on Information, Intelligence,
   Systems and Applications</em>, IISA 2014, pages 181&ndash;186. IEEE, July 2014.
 [&nbsp;<a href="cudpp_refs_bib.html#Glenis:2014:PAE">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1109/IISA.2014.6878727">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1109/IISA.2014.6878727">DOI</a>&nbsp;]
 
 </p>
 
@@ -48,7 +48,7 @@ Win-Tsung Lo, Yue-Shan Chang, Ruey-Kai Sheu, Chun-Chieh Chiu, and Shyan-Ming
  <b>CUDT: A CUDA Based Decision Tree Algorithm</b>.
  <em>The Scientific World Journal</em>, July 2014.
 [&nbsp;<a href="cudpp_refs_bib.html#Lo:2014:CAC">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1155/2014/745640">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1155/2014/745640">DOI</a>&nbsp;]
 
 </p>
 
@@ -59,7 +59,7 @@ Tsz&nbsp;Ho Wong, Geoff Leach, and Fabio Zambetta.
   deformable objects</b>.
  <em>The Visual Computer</em>, 30(6&ndash;8):729&ndash;738, May 2014.
 [&nbsp;<a href="cudpp_refs_bib.html#Wong:2014:AAO">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1007/s00371-014-0954-1">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1007/s00371-014-0954-1">DOI</a>&nbsp;]
 
 </p>
 
@@ -70,7 +70,7 @@ Anna Fabija&#x144;ska and Jaroslaw Goclawski.
   applying minimum spanning tree</b>.
  <em>IET Image Processing</em>, 8(4), April 2014.
 [&nbsp;<a href="cudpp_refs_bib.html#Fabijanska:2014:NAG">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1049/iet-ipr.2013.0104">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1049/iet-ipr.2013.0104">DOI</a>&nbsp;]
 
 </p>
 
@@ -81,7 +81,7 @@ Junjie Chen, Xiaogang Jin, and Zhigang Deng.
   surfaces</b>.
  <em>The Visual Computer</em>, pages 1&ndash;12, March 2014.
 [&nbsp;<a href="cudpp_refs_bib.html#Chen:2014:GPA">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1007/s00371-014-0924-7">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1007/s00371-014-0924-7">DOI</a>&nbsp;]
 
 </p>
 
@@ -102,7 +102,7 @@ Atle Riise and Edmund&nbsp;K Burke.
  <b>On parallel local search for permutations</b>.
  <em>Journal of the Operational Research Society</em>, 2014.
 [&nbsp;<a href="cudpp_refs_bib.html#Riise:2014:OPL">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1057/jors.2014.29">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1057/jors.2014.29">DOI</a>&nbsp;]
 
 </p>
 
@@ -114,7 +114,7 @@ Fadi&nbsp;N Sibai and Ali El-Moursy.
  <em>International Journal of Parallel, Emergent and Distributed
   Systems</em>, 29(1):38&ndash;67, January 2014.
 [&nbsp;<a href="cudpp_refs_bib.html#Sibai:2014:PEA">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1080/17445760.2012.762774">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1080/17445760.2012.762774">DOI</a>&nbsp;]
 
 </p>
 
@@ -125,7 +125,7 @@ Saima Parveen and Jaya Sreevalsan-Nair.
   Matrices</b>.
  In <em>Big Data Analytics</em>, pages 151&ndash;170. Springer, December 2013.
 [&nbsp;<a href="cudpp_refs_bib.html#Parveen:2013:VOS">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1007/978-3-319-03689-2_10">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1007/978-3-319-03689-2_10">DOI</a>&nbsp;]
 
 </p>
 
@@ -148,7 +148,7 @@ Qing Dai and Xubo Yang.
   on Virtual-Reality Continuum and Its Applications in Industry</em>, VRCAI '13,
   pages 177&ndash;182, New York, NY, USA, November 2013. ACM.
 [&nbsp;<a href="cudpp_refs_bib.html#Dai:2013:ISS">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1145/2534329.2534358">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1145/2534329.2534358">DOI</a>&nbsp;]
 
 </p>
 
@@ -161,7 +161,7 @@ Alejandro Hidalgo-Paniagua, Miguel&nbsp;A. Vega-Rodríguez, Nieves Pav&oacute;n,
  <em>Concurrency and Computation: Practice and Experience</em>, October
   2013.
 [&nbsp;<a href="cudpp_refs_bib.html#HidalgoPaniagua:2013:ACS">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1002/cpe.3163">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1002/cpe.3163">DOI</a>&nbsp;]
 
 </p>
 
@@ -183,7 +183,7 @@ Senhong Wang, Yan Zhao, Qiong Luo, Chao Wu, and Yang Xv.
  In <em>IEEE 9th International Conference on eScience</em>, pages
   326&ndash;333. IEEE, October 2013.
 [&nbsp;<a href="cudpp_refs_bib.html#Wang:2013:AIC">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1109/eScience.2013.9">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1109/eScience.2013.9">DOI</a>&nbsp;]
 
 </p>
 
@@ -194,7 +194,7 @@ Baoxue Zhao, Qiong Luo, and Chao Wu.
  In <em>IEEE 9th International Conference on eScience</em>, pages 88&ndash;97.
   IEEE, October 2013.
 [&nbsp;<a href="cudpp_refs_bib.html#Zhao:2013:PAS">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1109/eScience.2013.10">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1109/eScience.2013.10">DOI</a>&nbsp;]
 
 </p>
 
@@ -205,7 +205,7 @@ S&eacute;rgio Dias and Abel Gomes.
  In <em>Proceedings of the 20th European MPI Users' Group Meeting</em>,
   pages 181&ndash;186. ACM, September 2013.
 [&nbsp;<a href="cudpp_refs_bib.html#Dias:2013:TMS">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1145/2488551.2488582">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1145/2488551.2488582">DOI</a>&nbsp;]
 
 </p>
 
@@ -216,7 +216,7 @@ Mingcen Gao, Thanh-Tung Cao, Ashwin Nanjappa, Tiow-Seng Tan, and Zhiyong Huang.
  <em>ACM Transactions on Mathematical Software (TOMS)</em>, 40(1):3,
   September 2013.
 [&nbsp;<a href="cudpp_refs_bib.html#Gao:2013:GAG">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1145/2513109.2513112">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1145/2513109.2513112">DOI</a>&nbsp;]
 
 </p>
 
@@ -227,7 +227,7 @@ Yanwei Zhao, Qiang Qiu, Jinyun Fang, and Liang Li.
  In <em>IEEE International Geoscience and Remote Sensing Symposium</em>,
   IGARSS 2013, pages 3662&ndash;3665. IEEE, July 2013.
 [&nbsp;<a href="cudpp_refs_bib.html#Zhao:2013:FPI">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1109/IGARSS.2013.6723624">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1109/IGARSS.2013.6723624">DOI</a>&nbsp;]
 
 </p>
 
@@ -238,7 +238,7 @@ Mengjuan Li, Lianyin Jia, Jinguo You, Jianqing Xi, HaiFei Qin, and Rui Zeng.
   and its applications in web data query</b>.
  <em>World Wide Web</em>, pages 1&ndash;17, June 2013.
 [&nbsp;<a href="cudpp_refs_bib.html#Li:2013:FTQ">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1007/s11280-013-0232-6">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1007/s11280-013-0232-6">DOI</a>&nbsp;]
 
 </p>
 
@@ -249,7 +249,7 @@ XiaoQiang Zhu, XueKun Guo, and XiaoGang Jin.
   surfaces</b>.
  <em>Science China Information Sciences</em>, 56(3):1&ndash;12, March 2013.
 [&nbsp;<a href="cudpp_refs_bib.html#Zhu:2013:EPO">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1007/s11432-013-4790-0">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1007/s11432-013-4790-0">DOI</a>&nbsp;]
 
 </p>
 
@@ -273,7 +273,7 @@ M.&nbsp;L. S&aelig;tra.
   Numerical Mathematics and Advanced Applications 2011</em>, pages 673&ndash;680.
   Springer Berlin Heidelberg, 2013.
 [&nbsp;<a href="cudpp_refs_bib.html#Saetra:2013:SWS">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1007/978-3-642-33134-3_71">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1007/978-3-642-33134-3_71">DOI</a>&nbsp;]
 
 </p>
 
@@ -283,7 +283,7 @@ Xin Yang, Duan qing Xu, and Lei Zhao.
  <b>Efficient data management for incoherent ray tracing</b>.
  <em>Applied Soft Computing</em>, 13(1):1&ndash;8, January 2013.
 [&nbsp;<a href="cudpp_refs_bib.html#Yang:2013:EDM">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1016/j.asoc.2012.07.002">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1016/j.asoc.2012.07.002">DOI</a>&nbsp;]
 
 </p>
 
@@ -295,7 +295,7 @@ Andrew Davidson, David Tarjan, Michael Garland, and John&nbsp;D. Owens.
  In <em>Proceedings of Innovative Parallel Computing (InPar
   '12)</em>, May 2012.
 [&nbsp;<a href="cudpp_refs_bib.html#Davidson:2012:EPM">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1109/InPar.2012.6339592">DOI</a>&nbsp;| 
+<a href="https://doi.org/10.1109/InPar.2012.6339592">DOI</a>&nbsp;| 
 <a href="http://www.idav.ucdavis.edu/publications/print_pub?pub_id=1085">http</a>&nbsp;]
 
 </p>
@@ -307,7 +307,7 @@ Ritesh&nbsp;A. Patel, Yao Zhang, Jason Mak, and John&nbsp;D. Owens.
  In <em>Proceedings of Innovative Parallel Computing (InPar
   '12)</em>, May 2012.
 [&nbsp;<a href="cudpp_refs_bib.html#Patel:2012:PLD">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1109/InPar.2012.6339599">DOI</a>&nbsp;| 
+<a href="https://doi.org/10.1109/InPar.2012.6339599">DOI</a>&nbsp;| 
 <a href="http://www.idav.ucdavis.edu/publications/print_pub?pub_id=1087">http</a>&nbsp;]
 
 </p>
@@ -319,7 +319,7 @@ Ayal Stein, Eran Geva, and Jihad El-Sana.
  <em>Computers &amp; Graphics</em>, 36(4):265&ndash;271, March 2012.
  Applications of Geometry Processing.
 [&nbsp;<a href="cudpp_refs_bib.html#Stein:2012:CFP">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1016/j.cag.2012.02.012">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1016/j.cag.2012.02.012">DOI</a>&nbsp;]
 
 </p>
 
@@ -329,7 +329,7 @@ Yue-Shan Chang, Ruey-Kai Sheu, Shyan-Ming Yuan, and Jyn-Jie Hsu.
  <b>Scaling database performance on GPUs</b>.
  <em>Information Systems Frontiers</em>, 14(4):909&ndash;924, 2012.
 [&nbsp;<a href="cudpp_refs_bib.html#Chang:2012:SDP">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1007/s10796-011-9322-0">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1007/s10796-011-9322-0">DOI</a>&nbsp;]
 
 </p>
 
@@ -350,7 +350,7 @@ Pawan Harish, P.&nbsp;J. Narayanan, Vibhav Vineet, and Suryakant Patidar.
  In Wen mei W.&nbsp;Hwu, editor, <em>GPU Computing Gems Jade Edition</em>,
   pages 77&ndash;88. Morgan Kaufmann, Boston, 2012.
 [&nbsp;<a href="cudpp_refs_bib.html#Harish:2011:FMS">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1016/B978-0-12-385963-1.00007-1">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1016/B978-0-12-385963-1.00007-1">DOI</a>&nbsp;]
 
 </p>
 
@@ -363,7 +363,7 @@ Tyson&nbsp;J. Lipscomb, Anqi Zou, and Samuel&nbsp;S. Cho.
   Computational Biology and Biomedicine</em>, BCB '12, pages 321&ndash;328, New York,
   NY, USA, 2012. ACM.
 [&nbsp;<a href="cudpp_refs_bib.html#Lipscomb:2012:PVN">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1145/2382936.2382977">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1145/2382936.2382977">DOI</a>&nbsp;]
 
 </p>
 
@@ -375,7 +375,7 @@ Guilan Wang and Guoliang Zhou.
   Information Processing</em>, volume 288 of <em>Communications in Computer and
   Information Science</em>, pages 234&ndash;245. Springer Berlin Heidelberg, 2012.
 [&nbsp;<a href="cudpp_refs_bib.html#Wang:2012:GAO">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1007/978-3-642-31965-5_28">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1007/978-3-642-31965-5_28">DOI</a>&nbsp;]
 
 </p>
 
@@ -387,7 +387,7 @@ Ming Zeng, Fukai Zhao, Jiaxiang Zheng, and Xinguo Liu.
   Media</em>, volume 7633 of <em>Lecture Notes in Computer Science</em>, pages
   234&ndash;241. Springer Berlin Heidelberg, 2012.
 [&nbsp;<a href="cudpp_refs_bib.html#Zeng:2012:AMK">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1007/978-3-642-34263-9_30">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1007/978-3-642-34263-9_30">DOI</a>&nbsp;]
 
 </p>
 
@@ -399,7 +399,7 @@ Kun Zhou.
  <em>Frontiers of Electrical and Electronic Engineering</em>, 7(1):5&ndash;15,
   2012.
 [&nbsp;<a href="cudpp_refs_bib.html#Zhou:2012:GPC">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1007/s11460-012-0187-x">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1007/s11460-012-0187-x">DOI</a>&nbsp;]
 
 </p>
 
@@ -411,7 +411,7 @@ Iason Oikonomidis, Nikolaos Kyriazis, and Antonis Argyros.
  In <em>Proceedings of the British Machine Vision Conference</em>, pages
   101.1&ndash;101.11. BMVA Press, September 2011.
 [&nbsp;<a href="cudpp_refs_bib.html#Oikonomidis:2011:EM3">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.5244/C.25.101">DOI</a>&nbsp;]
+<a href="https://doi.org/10.5244/C.25.101">DOI</a>&nbsp;]
 
 </p>
 
@@ -423,7 +423,7 @@ Andrew Thall.
   Processing on Graphics Processing Units</em>, GPGPU-4, pages 6:1&ndash;6:8, New York,
   NY, USA, March 2011. ACM.
 [&nbsp;<a href="cudpp_refs_bib.html#Thall:2011:FMP">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1145/1964179.1964188">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1145/1964179.1964188">DOI</a>&nbsp;]
 
 </p>
 
@@ -434,7 +434,7 @@ Wu-chun Feng, Yong Cao, Debprakash Patnaik, and Naren Ramakrishnan.
  In Wen-mei&nbsp;W. Hwu, editor, <em>GPU Computing Gems</em>, volume&nbsp;1,
   chapter&nbsp;15, pages 211&ndash;227. Morgan Kaufmann, February 2011.
 [&nbsp;<a href="cudpp_refs_bib.html#Feng:2011:TDM">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1016/B978-0-12-384988-5.00015-2">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1016/B978-0-12-384988-5.00015-2">DOI</a>&nbsp;]
 
 </p>
 
@@ -446,7 +446,7 @@ Chun-Chieh Chiu, Guo-Heng Luo, and Shyan-Ming Yuan.
   Information Integration and Web-based Applications and Services</em>, iiWAS '11,
   pages 399&ndash;402, New York, NY, USA, 2011. ACM.
 [&nbsp;<a href="cudpp_refs_bib.html#Chiu:2011:DTU">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1145/2095536.2095615">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1145/2095536.2095615">DOI</a>&nbsp;]
 
 </p>
 
@@ -458,7 +458,7 @@ Eli&nbsp;Koffi Kouassi, Toshiyuki Amagasa, and Hiroyuki Kitagawa.
  <em>Procedia Computer Science</em>, 4(0):382&ndash;391, 2011.
  Proceedings of the International Conference on Computational Science.
 [&nbsp;<a href="cudpp_refs_bib.html#Kouassi:2011:EPL">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1016/j.procs.2011.04.040">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1016/j.procs.2011.04.040">DOI</a>&nbsp;]
 
 </p>
 
@@ -469,7 +469,7 @@ Chia-Feng Lin and Shyan-Ming Yuan.
  In <em>2011 Fifth International Conference on Genetic and
   Evolutionary Computing (ICGEC)</em>, pages 224&ndash;231, 2011.
 [&nbsp;<a href="cudpp_refs_bib.html#Lin:2011:TDA">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1109/ICGEC.2011.61">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1109/ICGEC.2011.61">DOI</a>&nbsp;]
 
 </p>
 
@@ -480,7 +480,7 @@ Weidong Sun, Weiwei Wang, and Zongmin Ma.
  In <em>2010 3rd International Conference on Biomedical Engineering
   and Informatics (BMEI)</em>, volume&nbsp;5, pages 2197&ndash;2200, October 2010.
 [&nbsp;<a href="cudpp_refs_bib.html#Sun:2010:FSE">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1109/BMEI.2010.5639638">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1109/BMEI.2010.5639638">DOI</a>&nbsp;]
 
 </p>
 
@@ -493,7 +493,7 @@ Dragan Bo&scaron;na&#x010D;ki, Stefan Edelkamp, Damien Sulewski, and Anton Wijs.
   Methods in Verification/ and Second International Workshop on High
   Performance Computational Systems Biology</em>, pages 17&ndash;19, September 2010.
 [&nbsp;<a href="cudpp_refs_bib.html#Bosnacki:2010:GAE">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1109/PDMC-HiBi.2010.11">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1109/PDMC-HiBi.2010.11">DOI</a>&nbsp;]
 
 </p>
 
@@ -504,7 +504,7 @@ Anjul Patney, Stanley Tzeng, and John&nbsp;D. Owens.
  <em>Computer Graphics Forum (Proceedings of the Eurographics
   Symposium on Rendering)</em>, 29(4):1251&ndash;1258, June 2010.
 [&nbsp;<a href="cudpp_refs_bib.html#Patney:2010:FCA">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1111/j.1467-8659.2010.01720.x">DOI</a>&nbsp;| 
+<a href="https://doi.org/10.1111/j.1467-8659.2010.01720.x">DOI</a>&nbsp;| 
 <a href="http://www.idav.ucdavis.edu/publications/print_pub?pub_id=1037">http</a>&nbsp;]
 
 </p>
@@ -516,7 +516,7 @@ Kirill Garanzha and Charles Loop.
   Ray Tracing</b>.
  <em>Computer Graphics Forum</em>, 29:289&ndash;298, May 2010.
 [&nbsp;<a href="cudpp_refs_bib.html#Garanzha:2010:FRS">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1111/j.1467-8659.2009.01598.x">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1111/j.1467-8659.2009.01598.x">DOI</a>&nbsp;]
 
 </p>
 
@@ -527,7 +527,7 @@ W.&nbsp;Bailer, H.&nbsp;Fassold, F.&nbsp;Lee, and J.&nbsp;Rosner.
  In <em>2010 Conference on Visual Media Production (CVMP)</em>, pages
   17&ndash;24, 2010.
 [&nbsp;<a href="cudpp_refs_bib.html#Bailer:2010:TAC">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1109/CVMP.2010.10">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1109/CVMP.2010.10">DOI</a>&nbsp;]
 
 </p>
 
@@ -551,7 +551,7 @@ Yupeng Guo, Xiaoguang Liu, Gang Wang, Fan Zhang, and Xin Zhao.
   volume 6082 of <em>Lecture Notes in Computer Science</em>, pages 289&ndash;296.
   Springer Berlin Heidelberg, 2010.
 [&nbsp;<a href="cudpp_refs_bib.html#Guo:2010:AIP">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1007/978-3-642-13136-3_30">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1007/978-3-642-13136-3_30">DOI</a>&nbsp;]
 
 </p>
 
@@ -563,7 +563,7 @@ D.&nbsp;Patnaik, S.&nbsp;P. Ponce, Yong Cao, and N.&nbsp;Ramakrishnan.
  In <em>Sixth IFIP International Conference on Network and Parallel
   Computing (NPC '09)</em>, pages 93&ndash;100, October 2009.
 [&nbsp;<a href="cudpp_refs_bib.html#Patnaik:2009:AAT">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1109/NPC.2009.26">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1109/NPC.2009.26">DOI</a>&nbsp;]
 
 </p>
 
@@ -586,7 +586,7 @@ Apeksha Godiyal, Jared Hoberock, Michael Garland, and John&nbsp;C. Hart.
   Drawing</em>, volume 5417 of <em>Lecture Notes in Computer Science</em>, pages
   90&ndash;101. Springer, September 2009.
 [&nbsp;<a href="cudpp_refs_bib.html#Godiyal:2009:RMG">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1007/978-3-642-00219-9">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1007/978-3-642-00219-9">DOI</a>&nbsp;]
 
 </p>
 
@@ -608,7 +608,7 @@ Markus Billeter, Ola Olsson, and Ulf Assarsson.
  In <em>Proceedings of High Performance Graphics 2009</em>, pages
   159&ndash;166, August 2009.
 [&nbsp;<a href="cudpp_refs_bib.html#Billeter:2009:ESC">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1145/1572769.1572795">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1145/1572769.1572795">DOI</a>&nbsp;]
 
 </p>
 
@@ -619,7 +619,7 @@ Jared Hoberock, Victor Lu, Yuntao Jia, and John&nbsp;C. Hart.
  In <em>Proceedings of High Performance Graphics 2009</em>, pages
   173&ndash;180, August 2009.
 [&nbsp;<a href="cudpp_refs_bib.html#Hoberock:2009:SCF">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1145/1572769.1572797">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1145/1572769.1572797">DOI</a>&nbsp;]
 
 </p>
 
@@ -631,7 +631,7 @@ Anjul Patney, Mohamed&nbsp;S. Ebeida, and John&nbsp;D. Owens.
  In <em>Proceedings of High Performance Graphics 2009</em>, pages
   99&ndash;108, August 2009.
 [&nbsp;<a href="cudpp_refs_bib.html#Patney:2009:PVT">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1145/1572769.1572785">DOI</a>&nbsp;| 
+<a href="https://doi.org/10.1145/1572769.1572785">DOI</a>&nbsp;| 
 <a href="http://graphics.idav.ucdavis.edu/publications/print_pub?pub_id=964">http</a>&nbsp;]
 
 </p>
@@ -643,7 +643,7 @@ Vibhav Vineet, Pawan Harish, Suryakant Patidar, and P.&nbsp;J. Narayanan.
  In <em>Proceedings of High Performance Graphics 2009</em>, pages
   167&ndash;171, August 2009.
 [&nbsp;<a href="cudpp_refs_bib.html#Vineet:2009:FMS">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1145/1572769.1572796">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1145/1572769.1572796">DOI</a>&nbsp;]
 
 </p>
 
@@ -685,7 +685,7 @@ Christian Eisenacher, Quirin Meyer, and Charles Loop.
  In <em>I3D '09: Proceedings of the 2009 Symposium on Interactive 3D
   Graphics and Games</em>, pages 137&ndash;143, February/March 2009.
 [&nbsp;<a href="cudpp_refs_bib.html#Eisenacher:2009:RTV">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1145/1507149.1507172">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1145/1507149.1507172">DOI</a>&nbsp;]
 
 </p>
 
@@ -695,8 +695,8 @@ Linh Ha, Jens Kr&uuml;ger, and Cl&aacute;udio&nbsp;T. Silva.
  <b>Fast Four-Way Parallel Radix Sorting on GPUs</b>.
  <em>Computer Graphics Forum</em>, 28(8):2368&ndash;2378, 2009.
 [&nbsp;<a href="cudpp_refs_bib.html#Ha:2009:FFP">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1111/j.1467-8659.2009.01542.x">DOI</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1111/j.1467-8659.2009.01542.x">http</a>&nbsp;]
+<a href="https://doi.org/10.1111/j.1467-8659.2009.01542.x">DOI</a>&nbsp;| 
+<a href="https://doi.org/10.1111/j.1467-8659.2009.01542.x">http</a>&nbsp;]
 
 </p>
 
@@ -707,7 +707,7 @@ B.&nbsp;Huang, Jinlan Gao, and Xiaoming Li.
  In <em>2009 IEEE International Symposium on Parallel and Distributed
   Processing with Applications</em>, pages 234&ndash;241, 2009.
 [&nbsp;<a href="cudpp_refs_bib.html#Huang:2009:AEO">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1109/ISPA.2009.89">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1109/ISPA.2009.89">DOI</a>&nbsp;]
 
 </p>
 
@@ -719,7 +719,7 @@ Yannick Allusse, Patrick Horain, Ankit Agarwal, and Cindula Saipriyadarshan.
  In <em>Advances in Visual Computing</em>, volume 5359 of <em>Lecture
   Notes in Computer Science</em>, pages 430&ndash;439. Springer, December 2008.
 [&nbsp;<a href="cudpp_refs_bib.html#Allusse:2008:GAG">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1007/978-3-540-89646-3">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1007/978-3-540-89646-3">DOI</a>&nbsp;]
 
 </p>
 
@@ -730,7 +730,7 @@ Anjul Patney and John&nbsp;D. Owens.
  <em>ACM Transactions on Graphics</em>, 27(5):143:1&ndash;143:8, December
   2008.
 [&nbsp;<a href="cudpp_refs_bib.html#Patney:2008:RRA">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1145/1409060.1409096">DOI</a>&nbsp;| 
+<a href="https://doi.org/10.1145/1409060.1409096">DOI</a>&nbsp;| 
 <a href="http://graphics.idav.ucdavis.edu/publications/print_pub?pub_id=952">http</a>&nbsp;]
 
 </p>
@@ -763,7 +763,7 @@ George Stantchev, William Dorland, and Nail Gumerov.
  <em>Journal of Parallel and Distributed Computing</em>,
   68(10):1339&ndash;1349, October 2008.
 [&nbsp;<a href="cudpp_refs_bib.html#Stantchev:2008:FPP">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1016/j.jpdc.2008.05.009">DOI</a>&nbsp;| 
+<a href="https://doi.org/10.1016/j.jpdc.2008.05.009">DOI</a>&nbsp;| 
 <a href="http://www.sciencedirect.com/science/article/B6WKJ-4SW144M-1/2/914e9b94290a555f36b8238a9781aa1d">http</a>&nbsp;]
 
 </p>
@@ -797,7 +797,7 @@ Alexander Ladikos, Selim Benhimane, and Nassir Navab.
  In <em>CVPRW '08: Computer Vision and Pattern Recognition
   Workshops</em>, pages 1&ndash;8, June 2008.
 [&nbsp;<a href="cudpp_refs_bib.html#Ladikos:2008:EVH">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1109/CVPRW.2008.4563098">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1109/CVPRW.2008.4563098">DOI</a>&nbsp;]
 
 </p>
 
@@ -810,7 +810,7 @@ Dominique Aubert, Mehdi Amini, and Romaric David.
   Computational Science</em>, volume 5544 of <em>Lecture Notes in Computer
   Science</em>, pages 874&ndash;883. Springer, May 2008.
 [&nbsp;<a href="cudpp_refs_bib.html#Aubert:2009:API">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1007/978-3-642-01970-8_88">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1007/978-3-642-01970-8_88">DOI</a>&nbsp;]
 
 </p>
 

--- a/source/shared_cudpp/doc/bib/cudpp_refs_bib.html
+++ b/source/shared_cudpp/doc/bib/cudpp_refs_bib.html
@@ -438,7 +438,7 @@
   number = 8,
   publisher = {Blackwell Publishing Ltd},
   issn = {1467-8659},
-  url = {<a href="http://dx.doi.org/10.1111/j.1467-8659.2009.01542.x">http://dx.doi.org/10.1111/j.1467-8659.2009.01542.x</a>},
+  url = {<a href="https://doi.org/10.1111/j.1467-8659.2009.01542.x">https://doi.org/10.1111/j.1467-8659.2009.01542.x</a>},
   doi = {10.1111/j.1467-8659.2009.01542.x},
   pages = {2368--2378},
   keywords = {HPC, GPGPU, GPU sorting, collision detection,
@@ -459,7 +459,7 @@
   year = 2012,
   pages = {77--88},
   isbn = {978-0-12-385963-1},
-  doi = {<a href="http://dx.doi.org/10.1016/B978-0-12-385963-1.00007-1">http://dx.doi.org/10.1016/B978-0-12-385963-1.00007-1</a>},
+  doi = {<a href="https://doi.org/10.1016/B978-0-12-385963-1.00007-1">https://doi.org/10.1016/B978-0-12-385963-1.00007-1</a>},
   author = {Pawan Harish and P. J. Narayanan and Vibhav Vineet
                   and Suryakant Patidar}
 }


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). It may be a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old `dx` subdomain is being redirected, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation by applying this update to all static DOI links.

Cheers!