### PR TITLE
Add missing DEBUG_FLAGS option to cuda_compile_ptx call for Linux

### DIFF
--- a/source/gvdb_library/cmake/Helpers.cmake
+++ b/source/gvdb_library/cmake/Helpers.cmake
@@ -82,7 +82,7 @@ FUNCTION( _COMPILEPTX )
         set( compile_target_ptx "${input_without_ext}_PTX")
         set( custom_command_var "${input_without_ext}_OUTPUT")
         # compile ptx
-        cuda_compile_ptx(custom_command_var ${input})
+        cuda_compile_ptx(custom_command_var ${input} OPTIONS "${DEBUG_FLAGS}")
         # This will only configure file generation, we need to add a target to
         # generate a file cuda_generated_<counter>_${input_without_ext}.ptx
         # Add custom command to rename to simply ${input_without_ext}.ptx

--- a/source/sample_utils/Helpers.cmake
+++ b/source/sample_utils/Helpers.cmake
@@ -82,7 +82,7 @@ FUNCTION( _COMPILEPTX )
         set( compile_target_ptx "${input_without_ext}_PTX")
         set( custom_command_var "${input_without_ext}_OUTPUT")
         # compile ptx
-        cuda_compile_ptx(custom_command_var ${input})
+        cuda_compile_ptx(custom_command_var ${input} OPTIONS "${DEBUG_FLAGS}")
         # This will only configure file generation, we need to add a target to
         # generate a file cuda_generated_<counter>_${input_without_ext}.ptx
         # Add custom command to rename to simply ${input_without_ext}.ptx


### PR DESCRIPTION
The custom `cuda_compile_ptx` calls for Linux in the CMakefiles are missing the `DEBUG_FLAGS` option, causing PTX files to be missing debug information even though the `USE_DEBUG_PTX` option is set to true.