### PR TITLE
Fix segfault in VolumeGVDB::ScatterDensity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/*
+install/*
+source/shared_cudpp/apps/common/include/common_config.h

--- a/source/gRenderKernel/main_renderkernel.cpp
+++ b/source/gRenderKernel/main_renderkernel.cpp
@@ -30,7 +30,7 @@
 CUmodule		cuCustom;
 CUfunction		cuRaycastKernel;
 
-bool cudaCheck ( CUresult status, char* msg )
+bool cudaCheck ( CUresult status, const char* msg )
 {
 	if ( status != CUDA_SUCCESS ) {
 		const char* stat = "";

--- a/source/gvdb_library/kernels/cuda_gvdb_copydata.cu
+++ b/source/gvdb_library/kernels/cuda_gvdb_copydata.cu
@@ -35,12 +35,12 @@ texture<float, cudaTextureType3D, cudaReadModeElementType>		volTexInF;
 surface<void, cudaTextureType3D>								volTexOut;
 
 // Zero memory of 3D volume
-extern "C" __global__ void kernelFillTex ( int3 res, int dsize )
+extern "C" __global__ void kernelFillTex ( int3 res, int dsize, float init_val )
 {
 	uint3 t = blockIdx * make_uint3(blockDim.x, blockDim.y, blockDim.z) + threadIdx;	
 	if ( t.x >= res.x || t.y >= res.y || t.z >= res.z ) return;
 
-	surf3Dwrite ( 0, volTexOut, t.x*dsize, t.y, t.z );
+	surf3Dwrite ( init_val, volTexOut, t.x*dsize, t.y, t.z );
 }
 
 // Copy 3D texture into sub-volume of another 3D texture (char)

--- a/source/gvdb_library/kernels/cuda_gvdb_nodes.cuh
+++ b/source/gvdb_library/kernels/cuda_gvdb_nodes.cuh
@@ -78,6 +78,8 @@ struct ALIGN(16) VDBInfo {
 	float3		bmax;	
 	cudaTextureObject_t		volIn[MAX_CHANNEL];
 	cudaSurfaceObject_t		volOut[MAX_CHANNEL];	
+	char*		atlas_dev_mem[MAX_CHANNEL];
+	bool		use_tex_mem[MAX_CHANNEL];
 };
 
 __device__ float								cdebug[256]; 

--- a/source/gvdb_library/kernels/cuda_gvdb_operators.cuh
+++ b/source/gvdb_library/kernels/cuda_gvdb_operators.cuh
@@ -98,13 +98,32 @@ extern "C" __global__ void gvdbUpdateApronF (VDBInfo* gvdb, uchar chan, int bric
 
 	// Get apron value
 	float3 wpos;
+	uint3 temp = make_uint3(node->mValue) - make_uint3(1,1,1);
 	if (!getAtlasToWorld(gvdb, vox, wpos)) return;
 	float3 offs, vmin, vdel; uint64 nid;
 	node = getNodeAtPoint(gvdb, wpos, &offs, &vmin, &vdel, &nid);		// Evaluate at world position
 	offs += (wpos - vmin) / vdel;
+	if(gvdb->use_tex_mem[chan]){
+		float v = (node == 0x0) ? boundval : tex3D<float>(gvdb->volIn[chan], offs.x, offs.y, offs.z);	// Sample at world point
+		surf3Dwrite(v, gvdb->volOut[chan], vox.x * sizeof(float), vox.y, vox.z);					// Write to apron voxel
+	}
+	else{
+		// if(blockIdx.x ==0 && blockIdx.y == 0 && threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0){
+		// 	printf("Brick id is %d, temp is %d %d %d\n", brk, temp.x, temp.y, temp.z);
+		// }
+		// if(brk == 0 && side == 3 && node != 0x0){
 
-	float v = (node == 0x0) ? boundval : tex3D<float>(gvdb->volIn[chan], offs.x, offs.y, offs.z);	// Sample at world point
-	surf3Dwrite(v, gvdb->volOut[chan], vox.x * sizeof(float), vox.y, vox.z);					// Write to apron voxel
+		// 	printf("temp:%u %u %u vox: %u %u %u brickres %d wpos: %f %f %f offs: %f %f %f\n", temp.x, temp.y, temp.z, vox.x, vox.y, vox.z, brickres, wpos.x, wpos.y, wpos.z, offs.x, offs.y, offs.z);
+		// }
+		uint3 off = make_uint3(offs.x, offs.y, offs.z);
+		int3 res = gvdb->atlas_res;
+		unsigned long int atlas_id = off.z * (res.x*res.y) + off.y * res.x + off.x ;
+		float *atlas_mem = (float *) (gvdb->atlas_dev_mem[chan]) + atlas_id;
+		float v = (node == 0x0) ? boundval : *atlas_mem;
+		atlas_id = vox.z * (res.x*res.y) + vox.y * res.x + vox.x ;
+		atlas_mem = (float *) (gvdb->atlas_dev_mem[chan]) + atlas_id;
+		*atlas_mem = v;
+	}
 }
 
 
@@ -445,7 +464,17 @@ extern "C" __global__ void gvdbOpFillF  ( VDBInfo* gvdb, int3 res, uchar chan, f
 		v += sinf( vox.z*12/(3.141592*30.0) );
 		surf3Dwrite ( v, gvdb->volOut[chan], vox.x*sizeof(float), vox.y, vox.z );
 	} else {
-		surf3Dwrite ( p1, gvdb->volOut[chan], vox.x*sizeof(float), vox.y, vox.z );
+		if(gvdb->use_tex_mem[chan]){
+			surf3Dwrite(p1, gvdb->volOut[chan], vox.x * sizeof(float), vox.y, vox.z);					// Write to apron voxel
+		}
+		else{
+			uint3 vox_fixed = vox - make_uint3(1, 1, 1);
+			int3 atlas_res = gvdb->atlas_res;
+			unsigned long int atlas_id = vox_fixed.z * atlas_res.x * atlas_res.y +
+                               vox_fixed.y * atlas_res.x + vox_fixed.x;
+			float* atlas_mem = (float*)(gvdb->atlas_dev_mem[chan]) + atlas_id;
+			*atlas_mem = p1;
+		}
 	}
 }
 extern "C" __global__ void gvdbOpFillC4 ( VDBInfo* gvdb, int3 res, uchar chan, float p1, float p2, float p3 )

--- a/source/gvdb_library/kernels/cuda_gvdb_raycast.cuh
+++ b/source/gvdb_library/kernels/cuda_gvdb_raycast.cuh
@@ -470,7 +470,8 @@ __device__ void rayDeepBrick ( VDBInfo* gvdb, uchar chan, int nodeid, float3 t, 
 
 		// depth buffer test [optional]
 		if (SCN_DBUF != 0x0) {
-			if (t.x > getLinearDepth(SCN_DBUF) ) {
+			float dist = t.x * fabsf(dot(scn.dir_vec, dir));
+			if (dist > getLinearDepth(SCN_DBUF) ) {
 				hit.y = length(wp - pos);
 				hit.z = 1;
 				clr = make_float4(fmin(clr.x, 1.f), fmin(clr.y, 1.f), fmin(clr.z, 1.f), fmax(clr.w, 0.f));
@@ -506,6 +507,8 @@ __device__ void rayCast ( VDBInfo* gvdb, uchar chan, float3 pos, float3 dir, flo
 	int		nodeid[MAXLEV];					// level variables
 	float	tMax[MAXLEV];
 	int		b;	
+	// Normalize incoming ray direction
+	dir = normalize(dir);
 
 	// GVDB - Iterative Hierarchical 3DDA on GPU
 	float3 vmin;	
@@ -530,7 +533,8 @@ __device__ void rayCast ( VDBInfo* gvdb, uchar chan, float3 pos, float3 dir, flo
 
 		// depth buffer test [optional]
 		if (SCN_DBUF != 0x0) {
-			if (t.x > getLinearDepth(SCN_DBUF) ) {
+			float dist = t.x * fabsf(dot(scn.dir_vec, normalize(dir)));
+			if (dist > getLinearDepth(SCN_DBUF) ) {
 				hit.z = 0;
 				return;
 			}

--- a/source/gvdb_library/kernels/cuda_gvdb_scene.cuh
+++ b/source/gvdb_library/kernels/cuda_gvdb_scene.cuh
@@ -78,6 +78,7 @@ struct ALIGN(16) ScnInfo {
 	float4*		transfer;
 	char*		outbuf;
   	char*   	dbuf;	
+	float3		dir_vec ;
 };
 
 struct ALIGN(16) ScnRay {

--- a/source/gvdb_library/src/gvdb_allocator.h
+++ b/source/gvdb_library/src/gvdb_allocator.h
@@ -110,11 +110,13 @@
 
 		// Texture functions
 		bool	TextureCreate ( uchar chan, uchar dtype, Vector3DI res, bool bCPU, bool bGL );
-		void	AllocateTextureGPU ( DataPtr& p, uchar dtype, Vector3DI res, bool bGL, uint64 preserve );
-		void	AllocateTextureCPU ( DataPtr& p, uint64 sz, bool bCPU, uint64 preserve );		
+		void	AllocateTextureGPU ( DataPtr& p, uchar dtype, Vector3DI res, bool bGL, uint64 preserve, Vector4DF init_val = {.0f, .0f, .0f, .0f} );
+		void	AllocateTextureCPU ( DataPtr& p, uint64 sz, bool bCPU, uint64 preserve, Vector4DF init_val = {.0f, .0f, .0f, .0f} );		
+		// Custom Extension for allocating device memory instead of texture
+		void 	AllocateAtlasMemGPU( DataPtr& p, uchar dtype, Vector3DI res, bool bGL, uint64 preserve, Vector4DF init_val = {.0f, .0f, .0f, .0f} );
 
 		// Atlas functions
-		bool	AtlasCreate ( uchar chan, uchar dtype, Vector3DI leafdim, Vector3DI axiscnt, char apr, uint64 map_wid, bool bCPU, bool bGL );		
+		bool	AtlasCreate ( uchar chan, uchar dtype, Vector3DI leafdim, Vector3DI axiscnt, char apr, uint64 map_wid, bool bCPU, bool bGL , bool use_tex_mem = true, Vector4DF init_val = {.0f, .0f, .0f, .0f} );		
 		bool	AtlasResize ( uchar chan, uint64 max_leaf );
 		bool	AtlasResize ( uchar chan, int cx, int cy, int cz );
 		void	AtlasSetNum ( uchar chan, int n );
@@ -161,6 +163,7 @@
 		int		getSize ( uchar dtype );
 		int		getNumAtlas ()					{ return (int) mAtlas.size(); }
 		DataPtr	getAtlas ( uchar chan )			{ return mAtlas[chan]; }	
+		bool 	getAtlasTexMem ( uchar chan )	{ return mAtlasTexMem[chan]; }	
 		float*	getAtlasCPU ( uchar chan )		{ return (float*) mAtlas[chan].cpu; }
 		int		getAtlasGLID ( uchar chan )		{ return mAtlas[chan].glid; }
 		uint64  getAtlasSize ( uchar chan )		{ return (uint64) mAtlas[chan].size; }
@@ -185,6 +188,8 @@
 		std::vector< DataPtr >		mPool[ MAX_POOL ];
 		std::vector< DataPtr >		mAtlas;
 		std::vector< DataPtr >		mAtlasMap;
+		std::vector< bool >			mAtlasTexMem;
+		std::vector< Vector4DF >	mAtlasInitVal;
 		DataPtr						mNeighbors;
 		bool						mbDebug;
 

--- a/source/gvdb_library/src/gvdb_camera.cpp
+++ b/source/gvdb_library/src/gvdb_camera.cpp
@@ -535,6 +535,7 @@ void Camera3D::setMatrices(const float* view_mtx, const float* proj_mtx, Vector3
 	mFov = 2.0f * atan(sx / mNear) / DEGtoRAD;
 
 	origRayWorld = from - model_pos;
+	dir_vec = inverseRayProj(0,0,mNear).Normalize();
 	updateFrustum();								// DO NOT call updateMatrices here. We have just set them.
 }
 

--- a/source/gvdb_library/src/gvdb_volume_gvdb.cpp
+++ b/source/gvdb_library/src/gvdb_volume_gvdb.cpp
@@ -790,12 +790,21 @@ void VolumeGVDB::SetupAtlasAccess ()
 			cudaCheck ( cuSurfObjectDestroy ( mVDBInfo.volOut[chan] ), "VolumeGVDB", "SetupAtlasAccess", "cuSurfObjectDestroy", chanmsg, mbDebug);
 			mVDBInfo.volOut[ chan ] = ID_UNDEFL;
 		}
-						
-		cudaCheck ( cuTexObjectCreate ( &mVDBInfo.volIn[chan], &resDesc, &texDesc, NULL ), "VolumeGVDB", "SetupAtlasAccess", "cuTexObjectCreate", chanmsg, mbDebug);
-		cudaCheck ( cuSurfObjectCreate ( &mVDBInfo.volOut[chan], &resDesc ), "VolumeGVDB", "SetupAtlasAccess", "cuSurfObjectCreate", chanmsg, mbDebug);
+
+		if(mPool->getAtlasTexMem(chan )){						
+			cudaCheck ( cuTexObjectCreate ( &mVDBInfo.volIn[chan], &resDesc, &texDesc, NULL ), "VolumeGVDB", "SetupAtlasAccess", "cuTexObjectCreate", chanmsg, mbDebug);
+			cudaCheck ( cuSurfObjectCreate ( &mVDBInfo.volOut[chan], &resDesc ), "VolumeGVDB", "SetupAtlasAccess", "cuSurfObjectCreate", chanmsg, mbDebug);
+			mVDBInfo.use_tex_mem[chan] = true;
+		}
+		else{
+			// Copy over the corresponding atlas pointer to atlas_dev_mem
+			mVDBInfo.atlas_dev_mem[chan] = atlas.gpu;
+			mVDBInfo.use_tex_mem[chan] = false;
+		}
 
 		if ( atlas.grsc != 0x0 )
 			cudaCheck ( cuGraphicsUnmapResources(1, &atlas.grsc, mStream), "VolumeGVDB", "SetupAtlasAccess", "cuGraphicsUnmapResources", chanmsg, mbDebug);
+	
 	}	
 	// Require VDBInfo update
 	mVDBInfo.update = true;
@@ -2646,7 +2655,7 @@ void VolumeGVDB::Configure ( int levs, int* r, int* numcnt, bool use_masks )
 }
 
 // Add a data channel (voxel attribute)
-void VolumeGVDB::AddChannel ( uchar chan, int dt, int apron, int filter, int border, Vector3DI axiscnt )
+void VolumeGVDB::AddChannel ( uchar chan, int dt, int apron, int filter, int border, Vector3DI axiscnt, bool use_tex_mem, Vector4DF init_val )
 {
 	PUSH_CTX
 
@@ -2656,11 +2665,9 @@ void VolumeGVDB::AddChannel ( uchar chan, int dt, int apron, int filter, int bor
 	}
 	mApron = apron;
 
-	mPool->AtlasCreate ( chan, dt, getRes3DI(0), axiscnt, apron, sizeof(AtlasNode), false, mbUseGLAtlas );
+	mPool->AtlasCreate ( chan, dt, getRes3DI(0), axiscnt, apron, sizeof(AtlasNode), false, mbUseGLAtlas, use_tex_mem, init_val );
 	mPool->AtlasSetFilter ( chan, filter, border );
-
 	SetupAtlasAccess ();	
-
 	POP_CTX
 }
 
@@ -4667,6 +4674,7 @@ void VolumeGVDB::PrepareRender ( int w, int h, char shading )
 	mScnInfo.outbuf		= -1;			// NOT USED  (was mRenderBuf[0].gpu;)
 	int dbuf = getScene()->getDepthBuf();
 	mScnInfo.dbuf 		= (dbuf == 255 ? NULL : mRenderBuf[dbuf].gpu);	
+	mScnInfo.dir_vec	= cam->dir_vec;
 
 	cudaCheck ( cuMemcpyHtoD ( cuScnInfo, &mScnInfo, sizeof(ScnInfo) ), "VolumeGVDB", "PrepareRender", "cuMemcpyHtoD", "cuScnInfo", mbDebug);
 

--- a/source/gvdb_library/src/gvdb_volume_gvdb.cpp
+++ b/source/gvdb_library/src/gvdb_volume_gvdb.cpp
@@ -6075,8 +6075,8 @@ void VolumeGVDB::ScatterDensity ( int num_pnts, float radius, float amp, Vector3
 		PrepareAux(AUX_COLAVG, 4 * num_voxels, sizeof(uint), true);					// node which each point falls into
 		if (mbProfile) PERF_POP();
     }
-	
-	void* args[13] = { &num_pnts, &radius, &amp, &mAux[AUX_PNTPOS].gpu, &mAux[AUX_PNTPOS].subdim.x, &mAux[AUX_PNTPOS].stride, &mAux[AUX_PNTCLR].gpu, &mAux[AUX_PNTCLR].subdim.x, &mAux[AUX_PNTCLR].stride, &mAux[AUX_PNODE].gpu, &trans.x, &expand, &mAux[AUX_COLAVG].gpu };
+
+	void *args[14] = {&cuVDBInfo, &num_pnts, &radius, &amp, &mAux[AUX_PNTPOS].gpu, &mAux[AUX_PNTPOS].subdim.x, &mAux[AUX_PNTPOS].stride, &mAux[AUX_PNTCLR].gpu, &mAux[AUX_PNTCLR].subdim.x, &mAux[AUX_PNTCLR].stride, &mAux[AUX_PNODE].gpu, &trans.x, &expand, &mAux[AUX_COLAVG].gpu};
 	cudaCheck ( cuLaunchKernel ( cuFunc[FUNC_SCATTER_DENSITY], pblks, 1, 1, threads, 1, 1, 0, NULL, args, NULL ), 
 				"VolumeGVDB", "ScatterPointDensity", "cuLaunch", "FUNC_SCATTER_DENSITY", mbDebug);		
 

--- a/source/gvdb_library/src/gvdb_volume_gvdb.h
+++ b/source/gvdb_library/src/gvdb_volume_gvdb.h
@@ -104,6 +104,8 @@
 		Vector3DF		bmax;				
 		CUtexObject		volIn[MAX_CHANNEL];
 		CUsurfObject	volOut[MAX_CHANNEL];
+		CUdeviceptr		atlas_dev_mem[MAX_CHANNEL];
+		bool			use_tex_mem[MAX_CHANNEL];
 	};
 
 	struct ALIGN(16) ScnInfo {
@@ -138,7 +140,8 @@
 		Vector3DF	thresh;
 		CUdeviceptr	transfer;
 		CUdeviceptr outbuf;
-		CUdeviceptr dbuf;		
+		CUdeviceptr dbuf;	
+		Vector3DF	dir_vec;	
 	};
 
 	// CUDA modules
@@ -393,7 +396,7 @@
 			void DestroyChannels ();
 			void SetChannelDefault ( int cx, int cy, int cz )	{ mDefaultAxiscnt.Set(cx,cy,cz); }
 			void SetApron ( int n )	 { mApron = n;}
-			void AddChannel ( uchar chan, int dt, int apron, int filter=F_LINEAR, int border=F_CLAMP, Vector3DI axiscnt = Vector3DI(0,0,0) );
+			void AddChannel ( uchar chan, int dt, int apron, int filter=F_LINEAR, int border=F_CLAMP, Vector3DI axiscnt = Vector3DI(0,0,0), bool use_tex_mem=true, Vector4DF init_val=Vector4DF{.0f,.0f,.0f,.0f});
 			void FillChannel ( uchar chan, Vector4DF val );
 			void ClearAllChannels ();
 			void ClearChannel(uchar chan);


### PR DESCRIPTION
Fix segmentation fault in `VolumeGVDB::ScatterDensity` caused by missing GVDB info parameter when launching the `ScatterPointDensity` kernel.