### PR TITLE
Added a destructor to fix memory leaks on object destruction

### DIFF
--- a/source/gvdb_library/src/gvdb_volume_gvdb.cpp
+++ b/source/gvdb_library/src/gvdb_volume_gvdb.cpp
@@ -2572,6 +2572,27 @@ void VolumeGVDB::Initialize ()
 	POP_CTX
 }
 
+VolumeGVDB::~VolumeGVDB(){
+	// Clear out all allocated channels and pools
+	DestroyChannels();
+	DataPtr temp;
+	SetPoints(temp, temp, temp);
+	CleanAux();
+	mPool->PoolReleaseAll();
+	// Deallocate cuVDBInfo object
+	if(cuVDBInfo != 0x0){
+		cudaCheck(cuMemFree(cuVDBInfo), "VolumeGVDB", "Destructor", "cuMemFree", "cuVDBInfo", mbDebug);
+	}
+	if(mTransferPtr.gpu!= 0x0){
+		cudaCheck(cuMemFree(mTransferPtr.gpu), "VolumeGVDB", "Destructor", "cuMemFree", "cuVDBInfo", mbDebug);
+	}
+	CUDPPResult result = CUDPP_SUCCESS;
+	result = cudppDestroyPlan(mPlan_max);
+	result = cudppDestroyPlan(mPlan_min);
+	result = cudppDestroyPlan(mPlan_sort);
+	if(result != CUDPP_SUCCESS) printf("Error in plan destruction!");
+}
+
 // Configure VDB tree (5-level)
 void VolumeGVDB::Configure ( int q4, int q3, int q2, int q1, int q0 )
 {

--- a/source/gvdb_library/src/gvdb_volume_gvdb.h
+++ b/source/gvdb_library/src/gvdb_volume_gvdb.h
@@ -343,7 +343,8 @@
 	
 	class GVDB_API VolumeGVDB : public VolumeBase {
 	public:
-			VolumeGVDB ();			
+			VolumeGVDB ();		
+			~VolumeGVDB();	
 			
 			// Setup
 			void SetCudaDevice ( int devid, CUcontext ctx=NULL );
@@ -504,6 +505,7 @@
 			int  getAtlasGLID ( int chan )	{ return mPool->getAtlasGLID ( chan ); }
 			int  getVDBSize ()				{ return sizeof(mVDBInfo); }
 			char* getVDBInfo ()				{ return (char*) &mVDBInfo; }
+			char* getcuVDBInfo ()				{ return (char*) &cuVDBInfo; }
 			int  getScnSize()				{ return sizeof(mScnInfo); }
 			char* getScnInfo()				{ return (char*) &mScnInfo; }			
 


### PR DESCRIPTION
GVDB doesn't clean up allocated GPU memory after itself. This becomes an issue when using multiple GVDB contexts. These are all the allocations I had to track down to get no more memory leaks in my application when run via
`cuda-memcheck --leak-check full`