### PR TITLE
Merges the packed-compute branch into master

### DIFF
--- a/source/gPointCloud/main_point_cloud.cpp
+++ b/source/gPointCloud/main_point_cloud.cpp
@@ -740,7 +740,7 @@ void Sample::render_update()
 	if (m_smooth > 0) {
 		PERF_PUSH("Smooth");
 		nvprintf("Smooth: %d, %f %f %f\n", m_smooth, m_smoothp.x, m_smoothp.y, m_smoothp.z);
-		gvdb.Compute( FUNC_SMOOTH, 0, m_smooth, m_smoothp, true, 3.0f);		// 8x smooth iterations	
+		gvdb.Compute( FUNC_SMOOTH, 0, m_smooth, m_smoothp, true, true, 3.0f);		// 8x smooth iterations	
 		PERF_POP();
 	}
 

--- a/source/gSprayDeposit/main_spray_deposit.cpp
+++ b/source/gSprayDeposit/main_spray_deposit.cpp
@@ -192,7 +192,7 @@ bool Sample::init()
 
 	// Fill color channel	
 	gvdb.FillChannel ( 1, Vector4DF(0.7f, 0.7f, 0.7f, 1) );
-	gvdb.Compute ( FUNC_SMOOTH, 0, 2, Vector3DF(4,0,0), true );
+	gvdb.Compute ( FUNC_SMOOTH, 0, 2, Vector3DF(4,0,0), true, true );
 	gvdb.UpdateApron ();
 
 	// Create opengl texture for display
@@ -312,7 +312,7 @@ void Sample::simulate()
 	// Smooth the volume
 	// A smoothing effect simulates gradual erosion
 	if ( int(m_time) % 20 == 0 ) {
-		gvdb.Compute ( FUNC_SMOOTH, 0, 1, Vector3DF(4,0,0), true ); 	
+		gvdb.Compute ( FUNC_SMOOTH, 0, 1, Vector3DF(4,0,0), true, true ); 	
 	}
 	
 }

--- a/source/gSprayDeposit/main_spray_deposit.cpp
+++ b/source/gSprayDeposit/main_spray_deposit.cpp
@@ -312,7 +312,7 @@ void Sample::simulate()
 	// Smooth the volume
 	// A smoothing effect simulates gradual erosion
 	if ( int(m_time) % 20 == 0 ) {
-		gvdb.Compute ( FUNC_SMOOTH, 0, 1, Vector3DF(4,0,0), true, true ); 	
+		gvdb.Compute(FUNC_SMOOTH, 0, 1, Vector3DF(4, 0, 0), true, false);
 	}
 	
 }

--- a/source/gvdb_library/src/gvdb_volume_gvdb.cpp
+++ b/source/gvdb_library/src/gvdb_volume_gvdb.cpp
@@ -4498,10 +4498,11 @@ void VolumeGVDB::ComputeKernel (CUmodule user_module, CUfunction user_kernel, uc
 
 	// Determine grid and block dims (must match atlas bricks)	
 	Vector3DI block ( 8, 8, 8 );
-	Vector3DI res = mPool->getAtlasRes( channel );
-	Vector3DI grid = (res + block - Vector3DI(1, 1, 1)) / block;
+	Vector3DI atlasRes = mPool->getAtlasRes(channel);
+	Vector3DI threadCount = (skipOverAprons ? mPool->getAtlasPackres(channel) : atlasRes);
+	Vector3DI grid = (threadCount + block - 1) / block;
 
-	void* args[3] = { &cuVDBInfo, &res, &channel };
+	void* args[3] = { &cuVDBInfo, &atlasRes, &channel };
 	cudaCheck ( cuLaunchKernel ( user_kernel, grid.x, grid.y, grid.z, block.x, block.y, block.z, 0, NULL, args, NULL ), 
 					"VolumeGVDB", "ComputeKernel", "cuLaunch", "(user kernel)", mbDebug);
 	

--- a/source/gvdb_library/src/gvdb_volume_gvdb.h
+++ b/source/gvdb_library/src/gvdb_volume_gvdb.h
@@ -364,8 +364,22 @@
 			char* getDataPtr ( int i, DataPtr dat )		{ return (dat.cpu + (i*dat.stride)); }			
 			
 			// Compute
-			void Compute ( int effect, uchar chan, int iter, Vector3DF parm, bool bUpdateApron, float boundval = 0.0f  );
-			void ComputeKernel ( CUmodule user_module, CUfunction user_kernel, uchar chan, bool bUpdateApron );
+			// For numIterations iterations, runs the native compute kernel with index
+			// `effect`, assuming it has the signature
+			// `effect(VDBInfo* gvdb, int3 atlasRes, uchar channel, float p1, float p2, float p3)`,
+			// then if `bUpdateApron` is true, updates the apron after each iteration
+			// with boundary value `boundval`.
+			// If `skipOverAprons` is true, it uses a grid of size `mPool->getAtlasResPacked(...)`;
+			// otherwise, it uses a grid of size `mPool->getAtlasRes(...)`.
+			// Passes the elements of `parameters` to the kernel as p1, p2, and p3.
+			void Compute ( int effect, uchar channel, int num_iterations, Vector3DF parameters, bool bUpdateApron, bool skipOverAprons, float boundval = 0.0f );
+			// Runs a custom user compute kernel, `user_kernel`, in the module `user_module`,
+			// passing in argument `channel`. This must have the function signature
+			// `func(VDBInfo* gvdb, int3 atlasRes, uchar channel)`
+			// If `bUpdateApron` is true, it updates all apron channels
+			// afterwards. If `skipOverAprons` is true, it uses a grid of size
+			// `mPool->getAtlasResPacked(...)`; otherwise, it uses a grid of size `mPool->getAtlasRes(...)`.
+			void ComputeKernel ( CUmodule user_module, CUfunction user_kernel, uchar channel, bool bUpdateApron, bool skipOverAprons);
 			void Resample ( uchar chan, Matrix4F xform, Vector3DI in_res, char in_aux, Vector3DF inr, Vector3DF outr );			
 			Vector3DF Reduction(uchar chan);
 			void DownsampleCPU(Matrix4F xform, Vector3DI in_res, char in_aux, Vector3DI out_res, Vector3DF out_max, char out_aux, Vector3DF inr, Vector3DF outr);


### PR DESCRIPTION
This makes it so that `Compute` and `ComputeKernel` can run kernels that avoid iterating over apron voxels, reducing the amount of computational work, while requiring that aprons be updated afterwards. This also updates the samples to include the new arguments to Compute and ComputeKernel, an API-breaking change.