### PR TITLE
Use fabsf where input is a float32

### DIFF
--- a/source/gFluidSurface/fluid_system.cpp
+++ b/source/gFluidSurface/fluid_system.cpp
@@ -693,7 +693,7 @@ void FluidSystem::Advance ()
 		// Wall barrier
 		if ( m_Toggle[PWALL_BARRIER] ) {
 			diff = 2 * radius - ( ppos->x - 0 )*ss;					
-			if (diff < 2*radius && diff > EPSILON && fabs(ppos->y) < 3 && ppos->z < 10) {
+			if (diff < 2*radius && diff > EPSILON && fabsf(ppos->y) < 3 && ppos->z < 10) {
 				norm.Set ( 1.0, 0, 0 );
 				adj = 2*stiff * diff - damp * (float) norm.Dot ( *pveleval ) ;	
 				accel.x += adj * norm.x; accel.y += adj * norm.y; accel.z += adj * norm.z;					
@@ -703,7 +703,7 @@ void FluidSystem::Advance ()
 		// Levy barrier
 		if ( m_Toggle[PLEVY_BARRIER] ) {
 			diff = 2 * radius - ( ppos->x - 0 )*ss;					
-			if (diff < 2*radius && diff > EPSILON && fabs(ppos->y) > 5 && ppos->z < 10) {
+			if (diff < 2*radius && diff > EPSILON && fabsf(ppos->y) > 5 && ppos->z < 10) {
 				norm.Set ( 1.0, 0, 0 );
 				adj = 2*stiff * diff - damp * (float) norm.Dot ( *pveleval ) ;	
 				accel.x += adj * norm.x; accel.y += adj * norm.y; accel.z += adj * norm.z;					
@@ -712,7 +712,7 @@ void FluidSystem::Advance ()
 		// Drain barrier
 		if ( m_Toggle[PDRAIN_BARRIER] ) {
 			diff = 2 * radius - ( ppos->z - bmin.z-15 )*ss;
-			if (diff < 2*radius && diff > EPSILON && (fabs(ppos->x)>3 || fabs(ppos->y)>3) ) {
+			if (diff < 2*radius && diff > EPSILON && (fabsf(ppos->x)>3 || fabsf(ppos->y)>3) ) {
 				norm.Set ( 0, 0, 1);
 				adj = stiff * diff - damp * (float) norm.Dot ( *pveleval );
 				accel.x += adj * norm.x; accel.y += adj * norm.y; accel.z += adj * norm.z;

--- a/source/gvdb_library/kernels/cuda_gvdb_particles.cuh
+++ b/source/gvdb_library/kernels/cuda_gvdb_particles.cuh
@@ -853,7 +853,7 @@ extern "C" __global__ void gvdbCheckVal (VDBInfo* gvdb, float slice, int3 res, i
 				int3 vox_pos = make_int3(fi+ii, pj+jj, fk+kk);
 				int3 tmp_vox = node->mValue + make_int3((vox_pos.x - vmin.x)/vdel.x, (vox_pos.y - vmin.y)/vdel.y, (vox_pos.z - vmin.z)/vdel.z);
 				float tmp_vel = surf3Dread<float>(gvdb->volOut[chanVy], tmp_vox.x * sizeof(float), tmp_vox.y, tmp_vox.z);
-				vel_y += tmp_vel * (1.0f - fabs(fi + ii + 0.5f - wpos.x)) * (1.0f - fabs(pj + jj - wpos.y)) * (1.0f - fabs(fk + kk + 0.5f - wpos.z));	
+				vel_y += tmp_vel * (1.0f - fabsf(fi + ii + 0.5f - wpos.x)) * (1.0f - fabsf(pj + jj - wpos.y)) * (1.0f - fabsf(fk + kk + 0.5f - wpos.z));	
 			}
 		}
 	} 

--- a/source/gvdb_library/kernels/cuda_math.cuh
+++ b/source/gvdb_library/kernels/cuda_math.cuh
@@ -1439,17 +1439,17 @@ inline __host__ __device__ float4 fmodf(float4 a, float4 b)
 // absolute value
 ////////////////////////////////////////////////////////////////////////////////
 
-inline __host__ __device__ float2 fabs(float2 v)
+inline __host__ __device__ float2 fabsf(float2 v)
 {
-    return make_float2(fabs(v.x), fabs(v.y));
+    return make_float2(fabsf(v.x), fabsf(v.y));
 }
-inline __host__ __device__ float3 fabs(float3 v)
+inline __host__ __device__ float3 fabsf(float3 v)
 {
-    return make_float3(fabs(v.x), fabs(v.y), fabs(v.z));
+    return make_float3(fabsf(v.x), fabsf(v.y), fabsf(v.z));
 }
-inline __host__ __device__ float4 fabs(float4 v)
+inline __host__ __device__ float4 fabsf(float4 v)
 {
-    return make_float4(fabs(v.x), fabs(v.y), fabs(v.z), fabs(v.w));
+    return make_float4(fabsf(v.x), fabsf(v.y), fabsf(v.z), fabsf(v.w));
 }
 
 inline __host__ __device__ int2 abs(int2 v)
@@ -1533,7 +1533,7 @@ inline __device__ __host__ float4 smoothstep(float4 a, float4 b, float4 x)
 
 inline __host__ __device__ float3 fabs3 ( float3 a )
 {
-	return make_float3 ( fabs(a.x), fabs(a.y), fabs(a.z) );
+	return make_float3 ( fabsf(a.x), fabsf(a.y), fabsf(a.z) );
 }
 inline __host__ __device__ float3 floor3 ( float3 a )
 {

--- a/source/gvdb_library/kernels/cuda_math.cuh
+++ b/source/gvdb_library/kernels/cuda_math.cuh
@@ -1439,15 +1439,15 @@ inline __host__ __device__ float4 fmodf(float4 a, float4 b)
 // absolute value
 ////////////////////////////////////////////////////////////////////////////////
 
-inline __host__ __device__ float2 fabsf(float2 v)
+inline __host__ __device__ float2 fabs(float2 v)
 {
     return make_float2(fabsf(v.x), fabsf(v.y));
 }
-inline __host__ __device__ float3 fabsf(float3 v)
+inline __host__ __device__ float3 fabs(float3 v)
 {
     return make_float3(fabsf(v.x), fabsf(v.y), fabsf(v.z));
 }
-inline __host__ __device__ float4 fabsf(float4 v)
+inline __host__ __device__ float4 fabs(float4 v)
 {
     return make_float4(fabsf(v.x), fabsf(v.y), fabsf(v.z), fabsf(v.w));
 }

--- a/source/sample_utils/optix_extra_math.cuh
+++ b/source/sample_utils/optix_extra_math.cuh
@@ -59,7 +59,7 @@ inline __host__ __device__ float3 operator*(int3 &a, float3 b)
 
 inline __host__ __device__ float3 fabs3 ( float3 a )
 {
-	return make_float3 ( fabs(a.x), fabs(a.y), fabs(a.z) );
+	return make_float3 ( fabsf(a.x), fabsf(a.y), fabsf(a.z) );
 }
 inline __host__ __device__ float3 floor3 ( float3 a )
 {


### PR DESCRIPTION
This PR unifies all absolute value usage where input is a float32 to be `fabsf`, replacing `fabs` use at places.