### PR TITLE
Optional OpenGL buffers in SolidVoxelise

### DIFF
--- a/source/gvdb_library/src/gvdb_volume_gvdb.cpp
+++ b/source/gvdb_library/src/gvdb_volume_gvdb.cpp
@@ -3475,13 +3475,13 @@ int VolumeGVDB::VoxelizeNode ( Node* node, uchar chan, Matrix4F* xform, float bd
 }
 
 // SolidVoxelize - Voxelize a polygonal mesh to a sparse volume
-void VolumeGVDB::SolidVoxelize ( uchar chan, Model* model, Matrix4F* xform, float val_surf, float val_inside, float vthresh )
+void VolumeGVDB::SolidVoxelize ( uchar chan, Model* model, Matrix4F* xform, float val_surf, float val_inside, float vthresh, bool use_opengl )
 {
 	PUSH_CTX
 
 	//TimerStart();
 	
-	AuxGeometryMap ( model, AUX_VERTEX_BUF, AUX_ELEM_BUF );					// Setup VBO for CUDA (interop)
+	if (use_opengl) AuxGeometryMap ( model, AUX_VERTEX_BUF, AUX_ELEM_BUF );					// Setup VBO for CUDA (interop)
 	
 	// Prepare model geometry for use by CUDA
 	cudaCheck ( cuMemcpyHtoD ( cuXform, xform->GetDataF(), sizeof(float)*16), "VolumeGVDB", "SolidVoxelize", "cuMemcpyHtoD", "cuXform", mbDebug );	// Send transform
@@ -3533,7 +3533,7 @@ void VolumeGVDB::SolidVoxelize ( uchar chan, Model* model, Matrix4F* xform, floa
 		PrepareV3D ( Vector3DI(0,0,0), 0 );
 	#endif
 
-	AuxGeometryUnmap ( model, AUX_VERTEX_BUF, AUX_ELEM_BUF );
+	if (use_opengl) AuxGeometryUnmap ( model, AUX_VERTEX_BUF, AUX_ELEM_BUF );
 
 	POP_CTX
 	//float msec = TimerStop();

--- a/source/gvdb_library/src/gvdb_volume_gvdb.h
+++ b/source/gvdb_library/src/gvdb_volume_gvdb.h
@@ -494,7 +494,7 @@
 			Extents ComputeExtents ( Node* node );
 			Extents ComputeExtents ( int lev, Vector3DF obj_min, Vector3DF obj_max );			
 			void SolidVoxelize ( uchar chan, Model* model, Matrix4F* xform, float val_surf, float val_inside, float vthresh=0.0 );
-			int VoxelizeNode ( Node* node, uchar chan, Matrix4F* xform, float bdiv, float val_surf, float val_inside, float vthresh = 0.0);
+			int VoxelizeNode ( Node* node, uchar chan, Matrix4F* xform, float bdiv, float val_surf, float val_inside, float vthresh = 0.0, bool use_opengl = true);
 			int ActivateRegion ( int lev, Extents& e );
 			int ActivateRegionFromAux(Extents& e, int auxid, uchar dt, float vthresh);
 			int ActivateHalo(Extents& e);


### PR DESCRIPTION
Hi,

I've been using SolidVoxelise on a branch where I have removed the requirement for meshes to be first uploaded to OpenGL
and then pushed into the GVDB AUX buffers. 
It removes the requirement on having an existing OpenGL context and lets users upload directly to GVDB.
Personally, I've found it quite useful to use SolidVoxelise when uploading data from .obj files. 

Defaulting the use_opengl to true means that it won't affect existing code, but it gives people more flexibility. 
Let me know what you think.

Cheers,
Aspen

Signed-off-by: Aspen Eyers <aspen.eyers@missionsystems.com.au>