### PR TITLE
Fixed missing arg in scatterDensity that would cause seg faults.

### DIFF
--- a/source/gvdb_library/src/gvdb_volume_gvdb.cpp
+++ b/source/gvdb_library/src/gvdb_volume_gvdb.cpp
@@ -5641,8 +5641,7 @@ void VolumeGVDB::ScatterDensity ( int num_pnts, float radius, float amp, Vector3
 		PrepareAux(AUX_COLAVG, 4 * num_voxels, sizeof(uint), true);					// node which each point falls into
 		if (mbProfile) PERF_POP();
     }
-	
-	void* args[13] = { &num_pnts, &radius, &amp, &mAux[AUX_PNTPOS].gpu, &mAux[AUX_PNTPOS].subdim.x, &mAux[AUX_PNTPOS].stride, &mAux[AUX_PNTCLR].gpu, &mAux[AUX_PNTCLR].subdim.x, &mAux[AUX_PNTCLR].stride, &mAux[AUX_PNODE].gpu, &trans.x, &expand, &mAux[AUX_COLAVG].gpu };
+	void* args[14] = { &cuVDBInfo, &num_pnts, &radius, &amp, &mAux[AUX_PNTPOS].gpu, &mAux[AUX_PNTPOS].subdim.x, &mAux[AUX_PNTPOS].stride, &mAux[AUX_PNTCLR].gpu, &mAux[AUX_PNTCLR].subdim.x, &mAux[AUX_PNTCLR].stride, &mAux[AUX_PNODE].gpu, &trans.x, &expand, &mAux[AUX_COLAVG].gpu };
 	cudaCheck ( cuLaunchKernel ( cuFunc[FUNC_SCATTER_DENSITY], pblks, 1, 1, threads, 1, 1, 0, NULL, args, NULL ), 
 				"VolumeGVDB", "ScatterPointDensity", "cuLaunch", "FUNC_SCATTER_DENSITY", mbDebug);		
 


### PR DESCRIPTION
Hi, 

I noticed that `VolumeGVDB::ScatterDensity` was seg faulting due to a missing argument. 
It looks like the gvdb data had accidentally been removed in an earlier push so I thought I'd fix it and 
submit a pull request. 

Signed-off-by: Aspen Eyers <aspen.eyers@missionsystems.com.au>