### PR TITLE
Patch to the platform.h sample_utils that define __aarch64__

### DIFF
--- a/source/sample_utils/platform.h
+++ b/source/sample_utils/platform.h
@@ -135,7 +135,7 @@ Platform define
 #   ifdef __CELLOS_LV2__
 #    define NV_PS3
 #        define NV_VMX
-#   elif defined(__arm__)
+#   elif defined(__arm__) || defined(__aarch64__)
 #        define NV_ARM
 #        if defined(__SNC__)
 #            define NV_PSP2


### PR DESCRIPTION
Platforms such as the Jetson Xavier (which is what I had made this modification for) define __aarch64__ instead
of __arm__.

Signed-off-by: Aspen Eyers <aspen.eyers@missionsystems.com.au>