### PR TITLE
Changed gvdb_types to print info to stderr instead of stdout.

### DIFF
--- a/source/gvdb_library/src/gvdb_types.cpp
+++ b/source/gvdb_library/src/gvdb_types.cpp
@@ -65,8 +65,9 @@ void gprintf2(va_list &vlist, const char * fmt, int level)
     default:
         break;
     }
-    ::printf(prefix);
-    ::printf(fmt2);
+    ::fprintf(stderr, prefix);
+    ::fprintf(stderr, fmt2);
+
 }
 void gprintf(const char * fmt, ...)
 {


### PR DESCRIPTION
gvdb_types.cpp was polluting stderr with debugging information which make applications that relied on stdout to function fail.

Signed-off-by: Aspen Eyers <aspen.eyers@missionsystems.com.au>